### PR TITLE
build: fix permissions for release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
 
     steps:


### PR DESCRIPTION
The workflow did not have permission to push to the repo. I think it just needs contents: write.