### PR TITLE
build: fix permissions for release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
 
     steps:
       - name: Checkout
@@ -26,5 +27,7 @@ jobs:
 
       - name: Perform release
         id: semrel
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./scripts/semanticrelease.sh


### PR DESCRIPTION
Missed a couple of points here. Needed some extra permissions for the github plugin in semantic-release. Also needed to explicitly pass the token to the job.