### PR TITLE
build: add extra types to release notes

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -18,7 +18,23 @@
                 ]
             }
         ],
-        "@semantic-release/release-notes-generator",
+        [
+            "@semantic-release/release-notes-generator",
+            {
+                "preset": "conventionalcommits",
+                "presetConfig": {
+                    "types": [
+                        { "type": "feat", "section": "Features" },
+                        { "type": "fix", "section": "Bug Fixes" },
+                        { "type": "perf", "section": "Performance Improvements" },
+                        { "type": "refactor", "section": "Code Refactoring" },
+                        { "type": "docs", "section": "Documentation" },
+                        { "type": "chore", "section": "Chores" },
+                        { "type": "ci", "section": "Release/Build changesgit"}
+                    ]
+                }
+            }
+        ],
         "@semantic-release/github"
     ]
 }

--- a/scripts/semanticrelease.sh
+++ b/scripts/semanticrelease.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 # Wrapper around semantic-release
 
-npx --yes --package semantic-release@25 semantic-release "$@"
+npx --yes --package semantic-release@25 \
+    --package conventional-changelog-conventionalcommits@9 \
+    semantic-release "$@"


### PR DESCRIPTION
Add a bit more info to release notes. This includes non-standard change types to give a bit more info.